### PR TITLE
Change the building toolchain to cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.o
 main
+build/
 
 .vscode/
 .ccls-cache/
 
 *.txt
+!CMakeLists.txt
 *hw*
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(my-bpnn)
+
+set(CMAKE_CXX_FLAGS "-std=c++17 -Wall -g")
+
+add_subdirectory(propagation)
+add_subdirectory(autograd)
+add_subdirectory(module)
+add_subdirectory(model)
+add_subdirectory(utils)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE model module data_generator)
+
+# file(GLOB_RECURSE MODEL_SRC "model/*.cpp")
+# add_library(model ${MODEL_SRC})
+# 
+# file(GLOB_RECURSE MODULE_SRC "module/*.cpp")
+# add_library(module ${MODULE_SRC})
+# target_link_libraries(module PRIVATE autograd)
+# 
+# add_library(data_generator "utils/data_generator.cpp")
+# 
+# file(GLOB_RECURSE AUTOGRAD_SRC "autograd/*.cpp")
+# file(GLOB_RECURSE PROPAGATION_SRC "propagation/*.cpp")
+# add_library(autograd ${AUTOGRAD_SRC} ${PROPAGATION_SRC})
+

--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ This is a simple implementation of Back Propagation Algorithm using C++.
 
 So far, this algorithm supports any number of Fully Connected Layer, as well as two kinds of activation function
 (Sigmoid and ReLU). The loss function is set to be TSELoss (Total Square Error).
+
+### Build and Run
+Make sure you have `cmake` in your system.
+
+```sh
+mkdir build && cd build
+cmake ..
+make
+./main
+```

--- a/autograd/CMakeLists.txt
+++ b/autograd/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(autograd)
+
+file(GLOB_RECURSE SRC *.cpp)
+add_library(${PROJECT_NAME} SHARED ${SRC})
+
+target_link_libraries(${PROJECT_NAME} PRIVATE propagation)

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(model)
+
+file(GLOB_RECURSE SRC *.cpp)
+add_library(${PROJECT_NAME} SHARED ${SRC})

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(module)
+
+file(GLOB_RECURSE SRC *.cpp)
+add_library(${PROJECT_NAME} SHARED ${SRC})
+target_link_libraries(${PROJECT_NAME} PRIVATE autograd)

--- a/propagation/CMakeLists.txt
+++ b/propagation/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(propagation)
+
+add_library(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(data_generator)
+
+add_library(${PROJECT_NAME} SHARED ${PROJECT_NAME}.cpp)


### PR DESCRIPTION
Change the building toolchain to cmake. It is easy to manage subproject and cross platform.